### PR TITLE
replace sporadic use of private attributes with public properties

### DIFF
--- a/sdxlib/sdx_client.py
+++ b/sdxlib/sdx_client.py
@@ -64,7 +64,7 @@ class SDXClient:
         self._name = name
         self._endpoints = endpoints
         self._description = description
-        self._notifications = self._validate_notifications(notifications)
+        self._notifications = notifications
         self._scheduling = scheduling
         self._qos_metrics = qos_metrics
         self._logger = logger or logging.getLogger(__name__)
@@ -482,33 +482,33 @@ class SDXClient:
             SDXException: If the L2VPN creation fails.
             ValueError: If required attributes are missing.
         """
-        if not self._base_url or not self._name or not self._endpoints:
+        if not self.base_url or not self.name or not self.endpoints:
             raise ValueError(
                 "Creating L2VPN requires the base URL, name, and endpoints at minumum."
             )
-        if not isinstance(self._endpoints, list):
+        if not isinstance(self.endpoints, list):
             raise TypeError("Endpoints must be a list.")
         url = f"{self.base_url}/l2vpn/{self.VERSION}"
         # print(url)
 
-        payload = {"name": self._name, "endpoints": self._endpoints}
+        payload = {"name": self.name, "endpoints": self.endpoints}
 
         # Add optional attributes if provided.
-        if self._description:
-            payload["description"] = self._description
-        if self._notifications:
-            payload["notifications"] = self._notifications
-        if self._scheduling:
-            payload["scheduling"] = self._scheduling
-        if self._qos_metrics:
-            payload["qos_metrics"] = self._qos_metrics
+        if self.description:
+            payload["description"] = self.description
+        if self.notifications:
+            payload["notifications"] = self.notifications
+        if self.scheduling:
+            payload["scheduling"] = self.scheduling
+        if self.qos_metrics:
+            payload["qos_metrics"] = self.qos_metrics
 
         self._logger.debug("Sending request to create L2VPN with payload: %s", payload)
 
         # Check cache for existing request with same name and endpoints
         cache_key = (
-            self._name,
-            tuple(endpoint["port_id"] for endpoint in self._endpoints),
+            self.name,
+            tuple(endpoint["port_id"] for endpoint in self.endpoints),
         )
         cached_data = self._request_cache.get(cache_key)
 
@@ -937,7 +937,7 @@ class SDXClient:
         Raises:
             SDXException: If the API request fails or returns an error.
         """
-        topology_url = f"{self._base_url}/topology"
+        topology_url = f"{self.base_url}/topology"
 
         try:
             response = requests.get(topology_url, timeout=10)

--- a/sdxlib/sdx_client.py
+++ b/sdxlib/sdx_client.py
@@ -60,13 +60,13 @@ class SDXClient:
         - scheduling (Optional[Dict[str, str]]): Scheduling configuration (default: None).
         - qos_metrics (Optional[Dict[str, str]]): Quality of service metrics (default: None).
         """
-        self._base_url = base_url
-        self._name = name
-        self._endpoints = endpoints
-        self._description = description
-        self._notifications = notifications
-        self._scheduling = scheduling
-        self._qos_metrics = qos_metrics
+        self.base_url = base_url
+        self.name = name
+        self.endpoints = endpoints
+        self.description = description
+        self.notifications = notifications
+        self.scheduling = scheduling
+        self.qos_metrics = qos_metrics
         self._logger = logger or logging.getLogger(__name__)
         self._request_cache = {}
 


### PR DESCRIPTION
In adding the http_username and http_password I realized that I had a few occasions where I was using the private attributes rather than the public properties. I believe I have corrected all of the instances of this and would like to merge the change into the main branch. 
