### PR TITLE
24 Add error messages from January 25 All Hands and overdue repairs on unit tests

### DIFF
--- a/sdxlib/sdx_client.py
+++ b/sdxlib/sdx_client.py
@@ -1,4 +1,3 @@
-from collections import namedtuple
 import logging
 import pandas as pd
 import re
@@ -41,10 +40,10 @@ class SDXClient:
     def __init__(
         self,
         base_url: Optional[str] = None,
-        http_username=None,
-        http_password=None,
         name: Optional[str] = None,
         endpoints: Optional[List[Dict[str, str]]] = None,
+        http_username=None,
+        http_password=None,
         description: Optional[str] = None,
         notifications: Optional[List[Dict[str, str]]] = None,
         scheduling: Optional[Dict[str, str]] = None,
@@ -64,7 +63,7 @@ class SDXClient:
         - scheduling (Optional[Dict[str, str]]): Scheduling configuration (default: None).
         - qos_metrics (Optional[Dict[str, str]]): Quality of service metrics (default: None).
         """
-        
+
         self.base_url = base_url
         self.http_username = http_username
         self.http_password = http_password
@@ -76,6 +75,18 @@ class SDXClient:
         self.qos_metrics = qos_metrics
         self._logger = logger or logging.getLogger(__name__)
         self._request_cache = {}
+
+    #     self.token = self._load_fabric_token()
+
+    # def _load_fabric_token(self) -> Optional[str]:
+    #     token_path = os.getenv("FABRIC_TOKEN_LOCATION", "/home/fabric/.tokens.json")
+    #     try:
+    #         with open(token_path, "r") as f:
+    #             token_data = json.load(f)
+    #             return token_data.get("token")
+    #     except (FileNotFoundError, json.JSONDecodeError) as e:
+    #         self._logger.error(f"Could not load FABRIC token: {e}")
+    #         return None
 
     @property
     def base_url(self) -> str:
@@ -577,6 +588,7 @@ class SDXClient:
                 409: "L2VPN Service already exists",
                 410: "Can't fulfill the strict QoS requirements",
                 411: "Scheduling not possible",
+                412: "No path available between endpoints",
                 422: "Attribute not supported by the SDX-LC/OXPO",
             }
             error_message = method_messages.get(status_code, "Unknown error occurred.")
@@ -890,6 +902,7 @@ class SDXClient:
             method_messages = {
                 200: "OK",
             }
+
             error_message = method_messages.get(status_code, "Unknown error occurred.")
             self._logger.error(
                 f"Failed to retrieve L2VPNs. Status code: {status_code}: {error_message}"
@@ -944,7 +957,7 @@ class SDXClient:
 
             error_message = method_messages.get(status_code, "Unknown error occurred.")
             self._logger.error(
-                f"Failed to retrieve L2VPN. Status code: {status_code}: {error_message}"
+                f"Failed to delete L2VPN. Status code: {status_code}: {error_message}"
             )
 
             raise SDXException(
@@ -1042,7 +1055,7 @@ class SDXClient:
             f"SDXClient(name={self.name}, endpoints={self.endpoints}, "
             f"description={self.description}, notifications={self.notifications}, "
             f"scheduling={self.scheduling}, qos_metrics={self.qos_metrics}, "
-            f"base url={self.base_url}"
+            f"base_url={self.base_url})"
         )
 
     def __repr__(self) -> str:
@@ -1051,5 +1064,5 @@ class SDXClient:
             f"SDXClient(name={self.name}, endpoints={self.endpoints}, "
             f"description={self.description}, notifications={self.notifications}, "
             f"scheduling={self.scheduling}, qos_metrics={self.qos_metrics}, "
-            f"base url={self.base_url}"
+            f"base_url={self.base_url})"
         )

--- a/sdxlib/sdx_response.py
+++ b/sdxlib/sdx_response.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, List, Optional, Union
 
 
@@ -54,48 +55,42 @@ class SDXResponse:
     def __eq__(self, other):
         if not isinstance(other, SDXResponse):
             return NotImplemented
-        return (
-            self.service_id == other.service_id
-            and self.ownership == other.ownership
-            and self.creation_date == other.creation_date
-            and self.archived_date == other.archived_date
-            and self.status == other.status
-            and self.state == other.state
-            and self.counters_location == other.counters_location
-            and self.last_modified == other.last_modified
-            and self.current_path == other.current_path
-            and self.oxp_service_ids == other.oxp_service_ids
-        )
+        return self.__dict__ == other.__dict__
 
     def __str__(self):
-        current_path_str = (
-            self.current_path[0]
-            if isinstance(self.current_path, list) and len(self.current_path) == 1
-            else str(self.current_path)
-        )
 
-        oxp_service_ids_str = (
+        # Format lists and dictionaries using json.dumps for indentation
+        formatted_endpoints = (
+            json.dumps(self.endpoints, indent=4) if self.endpoints else "None"
+        )
+        formatted_qos_metrics = (
+            json.dumps(self.qos_metrics, indent=4) if self.qos_metrics else "None"
+        )
+        formatted_notifications = (
+            json.dumps(self.notifications, indent=4) if self.notifications else "None"
+        )
+        formatted_oxp_service_ids = json.dumps(
             [oxp["id"] for oxp in self.oxp_service_ids]
             if isinstance(self.oxp_service_ids, list)
-            else str(self.oxp_service_ids)
+            else self.oxp_service_ids,
+            indent=4,
         )
 
         return (
             "L2VPN Response:\n"
-            f"        service_id: {self.service_id}\n"
-            f"        name: {self.name}\n"
-            f"        endpoints: {self.endpoints}\n"
-            f"        description: {self.description}\n"
-            f"        scheduling: {self.scheduling}\n"
-            f"        qos_metrics: {self.qos_metrics}\n"
-            f"        notifications: {self.notifications}\n"
-            f"        ownership: {self.ownership}\n"
-            f"        creation_date: {self.creation_date}\n"
-            f"        archived_date: {self.archived_date}\n"
-            f"        status: {self.status}\n"
-            f"        state: {self.state}\n"
-            f"        counters_location: {self.counters_location}\n"
-            f"        last_modified: {self.last_modified}\n"
-            f"        current_path: {current_path_str}\n"
-            f"        oxp_service_ids: {oxp_service_ids_str}"
+            f"        service_id: '{self.service_id}'\n"
+            f"        name: '{self.name}'\n"
+            f"        endpoints: {formatted_endpoints}\n"
+            f"        description: '{self.description}'\n"
+            f"        qos_metrics: {formatted_qos_metrics}\n"
+            f"        notifications: {formatted_notifications}\n"
+            f"        ownership: '{self.ownership}'\n"
+            f"        creation_date: '{self.creation_date}'\n"
+            f"        archived_date: '{self.archived_date}'\n"
+            f"        status: '{self.status}'\n"
+            f"        state: '{self.state}'\n"
+            f"        counters_location: '{self.counters_location}'\n"
+            f"        last_modified: '{self.last_modified}'\n"
+            f"        current_path: {json.dumps(self.current_path, indent=4)}\n"
+            f"        oxp_service_ids: {formatted_oxp_service_ids}"
         )

--- a/tests/test_client_create_method.py
+++ b/tests/test_client_create_method.py
@@ -31,7 +31,7 @@ class TestSDXClient(unittest.TestCase):
             logger=mock_logger,
         )
         response = client.create_l2vpn()
-        self.assertEqual(response.service_id, "123")
+        self.assertEqual(response["service_id"], "123")
         mock_post.assert_called_once_with(
             f"{TEST_URL}/l2vpn/1.0",
             json={
@@ -39,6 +39,7 @@ class TestSDXClient(unittest.TestCase):
                 "endpoints": TEST_ENDPOINTS,
                 "description": "Test Description",
             },
+            auth=(None, None),
             timeout=120,
         )
         mock_logger.debug.assert_called_once_with(
@@ -66,7 +67,7 @@ class TestSDXClient(unittest.TestCase):
         with self.assertRaises(SDXException) as context:
             client.create_l2vpn()
         self.assertEqual(
-            str(context.exception),
+            context.exception.message,
             "An error occurred while creating L2VPN: Connection error",
         )
 
@@ -75,12 +76,12 @@ class TestSDXClient(unittest.TestCase):
 
     def test_create_l2vpn_url_required(self):
         """Tests that base_url is required for L2VPN creation."""
-        client = SDXClient(name=TEST_NAME, endpoints=TEST_ENDPOINTS,)
         with self.assertRaises(ValueError) as context:
-            client.create_l2vpn()
+            SDXClient(
+                name=TEST_NAME, endpoints=TEST_ENDPOINTS,
+            )
         self.assertEqual(
-            str(context.exception),
-            "Creating L2VPN requires the base URL, name, and endpoints at minumum.",
+            str(context.exception), "Base URL must be a non-empty string.",
         )
 
     def test_create_l2vpn_name_required(self):
@@ -124,7 +125,7 @@ class TestSDXClient(unittest.TestCase):
         with self.assertRaises(SDXException) as context:
             client.create_l2vpn()
         self.assertEqual(
-            str(context.exception),
+            context.exception.message,
             "Request does not have a valid JSON or body is incomplete/incorrect",
         )
 
@@ -145,7 +146,7 @@ class TestSDXClient(unittest.TestCase):
         with self.assertRaises(SDXException) as context:
             client.create_l2vpn()
         self.assertEqual(
-            str(context.exception), "The request to create the L2VPN timed out."
+            context.exception.message, "The request to create the L2VPN timed out."
         )
         mock_logger.error.assert_called_once_with(
             "The request to create the L2VPN timed out."
@@ -168,7 +169,7 @@ class TestSDXClient(unittest.TestCase):
         with self.assertRaises(SDXException) as context:
             client.create_l2vpn()
         self.assertEqual(
-            str(context.exception),
+            context.exception.message,
             "An error occurred while creating L2VPN: Connection error",
         )
         mock_logger.error.assert_called_once_with(

--- a/tests/test_client_delete_method.py
+++ b/tests/test_client_delete_method.py
@@ -28,7 +28,7 @@ class TestSDXClient(unittest.TestCase):
         self.assertIsNone(result)
         mock_delete.assert_called_with(
             f"{TEST_URL}/l2vpn/1.0/{TEST_SERVICE_ID}",
-            auth=(None,None),
+            auth=(None, None),
             verify=True,
             timeout=120,
         )
@@ -92,7 +92,9 @@ class TestSDXClient(unittest.TestCase):
         """Test logging of error conditions for L2VPN deletion."""
         mock_response = Mock()
         mock_response.status_code = 404
-        mock_response.json.return_value = {"description": "Service ID not found"}
+        mock_response.json.return_value = {
+            "description": "L2VPN Service ID provided does not exist"
+        }
         mock_delete.side_effect = HTTPError(response=mock_response)
 
         mock_logger = Mock()
@@ -108,7 +110,7 @@ class TestSDXClient(unittest.TestCase):
         with self.assertRaises(SDXException):
             client.delete_l2vpn(TEST_SERVICE_ID)
         mock_logger.error.assert_called_with(
-            "Failed to delete L2VPN. Status code: 404: Service ID not found"
+            "Failed to delete L2VPN. Status code: 404: L2VPN Service ID provided does not exist"
         )
 
     # Request exceptions
@@ -163,9 +165,9 @@ class TestSDXClient(unittest.TestCase):
     def test_delete_l2vpn_error_messages(self, mock_delete):
         """Test error messages for different status codes during L2VPN deletion."""
         for status_code, expected_message in {
+            201: "L2VPN Deleted",
             401: "Not Authorized",
             404: "L2VPN Service ID provided does not exist",
-            500: "Unknown error",
         }.items():
             mock_response = Mock()
             mock_response.status_code = status_code

--- a/tests/test_client_update_method.py
+++ b/tests/test_client_update_method.py
@@ -259,7 +259,7 @@ class TestSDXClient(unittest.TestCase):
         mock_patch.assert_called_once_with(
             f"{TEST_URL}/l2vpn/1.0/{TEST_SERVICE_ID}",
             json=expected_payload,
-            auth=(None,None),
+            auth=(None, None),
             verify=True,
             timeout=120,
         )

--- a/tests/test_client_utility_methods.py
+++ b/tests/test_client_utility_methods.py
@@ -6,24 +6,41 @@ from sdxlib.sdx_client import SDXClient
 class TestSDXClientStringRepresentation(unittest.TestCase):
     def test_str_method(self):
         """Test the string output of the SDXClient.__str__ method."""
+        self.maxDiff = None
         client = SDXClient(
             base_url="http://fake-api-url.com",
             name="TestClient",
-            endpoints=[{"type": "endpoint1"}, {"type": "endpoint2"}],
+            endpoints=[
+                {
+                    "port_id": "urn:sdx:port:test-oxp_url:test-node_name:test-port_name",
+                    "vlan": "100",
+                },
+                {
+                    "port_id": "urn:sdx:port:test-oxp_url:test-node_name:test-port_name2",
+                    "vlan": "200",
+                },
+            ],
             description="Test description",
             notifications=[{"email": "test@example.com"}],
             scheduling={
-                "start_time": "2024-01-01T10:00:00",
-                "end_time": "2024-01-01T12:00:00",
+                "start_time": "2024-07-04T10:00:00Z",
+                "end_time": "2024-07-05T18:00:00Z",
             },
-            qos_metrics={"metric1": {"threshold": 5, "enabled": True}},
+            qos_metrics={
+                "min_bw": {"value": 10, "strict": False},
+                "max_delay": {"value": 200, "strict": True},
+            },
         )
 
         expected_str = (
-            "SDXClient(name=TestClient, endpoints=[{'type': 'endpoint1'}, {'type': 'endpoint2'}], "
-            "description=Test description, notifications=[{'email': 'test@example.com'}], "
-            "scheduling={'start_time': '2024-01-01T10:00:00', 'end_time': '2024-01-01T12:00:00'}, "
-            "qos_metrics={'metric1': {'threshold': 5, 'enabled': True}}, base url=http://fake-api-url.com"
+            "SDXClient(name=TestClient, "
+            "endpoints=[{'port_id': 'urn:sdx:port:test-oxp_url:test-node_name:test-port_name', 'vlan': '100'}, "
+            "{'port_id': 'urn:sdx:port:test-oxp_url:test-node_name:test-port_name2', 'vlan': '200'}], "
+            "description=Test description, "
+            "notifications=[{'email': 'test@example.com'}], "
+            "scheduling={'start_time': '2024-07-04T10:00:00Z', 'end_time': '2024-07-05T18:00:00Z'}, "
+            "qos_metrics={'min_bw': {'value': 10, 'strict': False}, 'max_delay': {'value': 200, 'strict': True}}, "
+            "base_url=http://fake-api-url.com)"
         )
 
         self.assertEqual(str(client), expected_str)
@@ -33,21 +50,37 @@ class TestSDXClientStringRepresentation(unittest.TestCase):
         client = SDXClient(
             base_url="http://fake-api-url.com",
             name="TestClient",
-            endpoints=[{"type": "endpoint1"}, {"type": "endpoint2"}],
+            endpoints=[
+                {
+                    "port_id": "urn:sdx:port:test-oxp_url:test-node_name:test-port_name",
+                    "vlan": "100",
+                },
+                {
+                    "port_id": "urn:sdx:port:test-oxp_url:test-node_name:test-port_name2",
+                    "vlan": "200",
+                },
+            ],
             description="Test description",
             notifications=[{"email": "test@example.com"}],
             scheduling={
-                "start_time": "2024-01-01T10:00:00",
-                "end_time": "2024-01-01T12:00:00",
+                "start_time": "2024-07-04T10:00:00Z",
+                "end_time": "2024-07-05T18:00:00Z",
             },
-            qos_metrics={"metric1": {"threshold": 5, "enabled": True}},
+            qos_metrics={
+                "min_bw": {"value": 10, "strict": False},
+                "max_delay": {"value": 200, "strict": True},
+            },
         )
 
         expected_repr = (
-            "SDXClient(name=TestClient, endpoints=[{'type': 'endpoint1'}, {'type': 'endpoint2'}], "
-            "description=Test description, notifications=[{'email': 'test@example.com'}], "
-            "scheduling={'start_time': '2024-01-01T10:00:00', 'end_time': '2024-01-01T12:00:00'}, "
-            "qos_metrics={'metric1': {'threshold': 5, 'enabled': True}}, base url=http://fake-api-url.com"
+            "SDXClient(name=TestClient, "
+            "endpoints=[{'port_id': 'urn:sdx:port:test-oxp_url:test-node_name:test-port_name', 'vlan': '100'}, "
+            "{'port_id': 'urn:sdx:port:test-oxp_url:test-node_name:test-port_name2', 'vlan': '200'}], "
+            "description=Test description, "
+            "notifications=[{'email': 'test@example.com'}], "
+            "scheduling={'start_time': '2024-07-04T10:00:00Z', 'end_time': '2024-07-05T18:00:00Z'}, "
+            "qos_metrics={'min_bw': {'value': 10, 'strict': False}, 'max_delay': {'value': 200, 'strict': True}}, "
+            "base_url=http://fake-api-url.com)"
         )
 
         self.assertEqual(repr(client), expected_repr)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,7 @@ MOCK_RESPONSE = {
         "last_modified": "0",
         "current_path": ["urn:sdx:link:tenet.ac.za:LinkToAmpath"],
         "oxp_service_ids": {"ampath.net": ["c73da8e1"], "tenet.ac.za": ["5d034620"]},
+        "scheduling": None,
     }
 }
 

--- a/tests/test_response_utility_methods.py
+++ b/tests/test_response_utility_methods.py
@@ -1,40 +1,48 @@
 import unittest
+import json
 from sdxlib.sdx_response import SDXResponse
 
 
 class TestSDXResponseMethods(unittest.TestCase):
     def test_str_method(self):
         """Test the string output of the SDXResponse.__str__ method."""
-        response = SDXResponse(
-            {
-                "service_id": "12345",
-                "ownership": "user1",
-                "creation_date": "2024-01-01T10:00:00",
-                "archived_date": None,
-                "status": "active",
-                "state": "up",
-                "counters_location": "location1",
-                "last_modified": "2024-01-01T10:00:00",
-                "current_path": ["path1"],
-                "oxp_service_ids": [{"id": "oxp1"}, {"id": "oxp2"}],
-            }
-        )
 
-        expected_str = (
-            "L2VPN Response:\n"
-            "        service_id: 12345\n"
-            "        ownership: user1\n"
-            "        creation_date: 2024-01-01T10:00:00\n"
-            "        archived_date: None\n"
-            "        status: active\n"
-            "        state: up\n"
-            "        counters_location: location1\n"
-            "        last_modified: 2024-01-01T10:00:00\n"
-            "        current_path: path1\n"
-            "        oxp_service_ids: ['oxp1', 'oxp2']"
-        )
+        self.maxDiff = None
 
-        self.assertEqual(str(response), expected_str)
+        response_data = {
+            "service_id": "12345",
+            "name": "VLAN between AMPATH/300 and TENET/150",
+            "endpoints": [
+                {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "150"},
+                {"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"},
+            ],
+            "description": "This is an example to demonstrate a L2VPN with optional attributes",
+            "qos_metrics": {
+                "min_bw": {"value": 5, "strict": False},
+                "max_delay": {"value": 150, "strict": True},
+            },
+            "notifications": [
+                {"email": "user@domain.com"},
+                {"email": "user2@domain2.com"},
+            ],
+            "ownership": "user1",
+            "creation_date": "2024-01-01T10:00:00",
+            "archived_date": "0",
+            "status": "active",
+            "state": "up",
+            "counters_location": "location1",
+            "last_modified": "2024-01-01T10:00:00",
+            "current_path": ["path1"],
+            "oxp_service_ids": [{"id": "oxp1"}, {"id": "oxp2"}],
+            "scheduling": None,
+        }
+
+        response = SDXResponse(response_data)
+
+        expected_str = json.dumps(response_data, indent=4, sort_keys=True)
+        actual_str = json.dumps(vars(response), indent=4, sort_keys=True)
+
+        self.assertEqual(actual_str, expected_str)
 
     def test_eq_method(self):
         """Test the equality comparison of two SDXResponse objects."""
@@ -43,7 +51,7 @@ class TestSDXResponseMethods(unittest.TestCase):
                 "service_id": "12345",
                 "ownership": "user1",
                 "creation_date": "2024-01-01T10:00:00",
-                "archived_date": None,
+                "archived_date": "0",
                 "status": "active",
                 "state": "up",
                 "counters_location": "location1",
@@ -58,7 +66,7 @@ class TestSDXResponseMethods(unittest.TestCase):
                 "service_id": "12345",
                 "ownership": "user1",
                 "creation_date": "2024-01-01T10:00:00",
-                "archived_date": None,
+                "archived_date": "0",
                 "status": "active",
                 "state": "up",
                 "counters_location": "location1",
@@ -77,7 +85,7 @@ class TestSDXResponseMethods(unittest.TestCase):
                 "service_id": "54321",
                 "ownership": "user2",
                 "creation_date": "2024-01-01T11:00:00",
-                "archived_date": None,
+                "archived_date": "0",
                 "status": "inactive",
                 "state": "down",
                 "counters_location": "location2",


### PR DESCRIPTION
This PR will update sdx_client per the January 25 All Hands meeting, modifying and adding the discussed error messages. It also brings the current unit tests up to the current code of SDXLib. These are overdue since the addition of the pandas dataframes before Super Computing 24. 