### PR TITLE
Fix Double Instantiation of SDXClient During L2VPN Creation #65

### DIFF
--- a/sdxlib/sdx_client.py
+++ b/sdxlib/sdx_client.py
@@ -41,10 +41,13 @@ class SDXClient:
         self._logger = logger or logging.getLogger(__name__)
         self._request_cache = {}
 
-    def create_l2vpn(self) -> dict:
+    def create_l2vpn(self, name: str, endpoints: List[Dict[str, str]]) -> dict:
         """Creates an L2VPN."""
         # Perform validation using SDXValidator
         SDXValidator.validate_required_attributes(self.base_url, self.name, self.endpoints)
+
+        self.name = SDXValidator.validate_name(name)
+        self.endpoints = SDXValidator.validate_endpoints(endpoints)
 
         url = f"{self.base_url}/l2vpn/{self.VERSION}"
         payload = self._build_payload()


### PR DESCRIPTION
Previously, the create_l2vpn() method relied on self.name and self.endpoints already being set before invocation. In several use cases, this led to unintentional double instantiation of the SDXClient class — once to set attributes like name and endpoints, and again to call create_l2vpn() using those attributes.

This design was:

Redundant (required users to prepopulate the instance before calling the method).

Error-prone (risk of stale or uninitialized internal state).

Difficult to test (state mutation scattered across instantiation and method calls).

Fix Summary:

Refactored create_l2vpn() to accept name and endpoints as arguments.

These values are now validated and assigned to the instance within the method itself.

This eliminates the need for pre-initialization and prevents double instantiation.