### PR TITLE
adding default parameter to validate_option to properly change the optional attributes

### DIFF
--- a/sdxlib/sdx_response.py
+++ b/sdxlib/sdx_response.py
@@ -93,14 +93,14 @@ class SDXResponse:
             response_json, "description", str
         )
         self.notifications: Optional[List[Dict[str, str]]] = self._validate_optional(
-            response_json, "notifications", list
+            response_json, "notifications", list, default=[]
         )
         self.scheduling: Optional[Dict[str, str]] = self._validate_optional(
-            response_json, "scheduling", dict
+            response_json, "scheduling", dict, default={}
         )
         self.qos_metrics: Optional[
             Dict[str, Dict[str, Union[int, bool]]]
-        ] = self._validate_optional(response_json, "qos_metrics", dict)
+        ] = self._validate_optional(response_json, "qos_metrics", dict, default={})
 
         # Log successful validation
         self._logger.debug("SDXResponse successfully initialized.")
@@ -138,9 +138,9 @@ class SDXResponse:
 
         return value
 
-    def _validate_optional(self, data: dict, key: str, expected_type: type):
+    def _validate_optional(self, data: dict, key: str, expected_type: type, default=None):
         """Validates optional fields and ensures correct type if present."""
-        value = data.get(key)
+        value = data.get(key, default)
 
         if value is not None and not isinstance(value, expected_type):
             self._logger.warning(


### PR DESCRIPTION
some attributes that are optional were being set with None value and consumed with loops later on, which would lead to the following error:

```
File [/opt/conda/lib/python3.11/site-packages/sdxlib/sdx_client.py:343](https://jupyter.fabric-testbed.net/opt/conda/lib/python3.11/site-packages/sdxlib/sdx_client.py#line=342), in <listcomp>(.0)
    331     print("No L2VPNs found.")
    332     return None
    334 formatted = [
    335     {
    336         "Service ID": sid,
    337         "Name": l2vpn.name,
    338         "Endpoints": [
    339             {"port_id": endpoint.get("port_id", "Unknown"), "vlan": endpoint.get("vlan", "Unknown")}
    340             for endpoint in l2vpn.endpoints
    341         ],
    342         "Ownership": l2vpn.ownership,
--> 343         "Notifications": ", ".join(
    344             notification.get("email", "Unknown") if isinstance(notification, dict) else str(notification)
    345             for notification in l2vpn.notifications
    346         ),
    347         "Scheduling": str(l2vpn.scheduling or "None"),
    348         "QoS Metrics": str(l2vpn.qos_metrics or "None")
    349     }
    350     for sid, l2vpn in l2vpns.items()
    351 ]
    353 if format == "dataframe":
    354     return pd.DataFrame(formatted)

TypeError: 'NoneType' object is not iterable
```