### PR TITLE
Fix optional attributes default value

### DIFF
--- a/sdxlib/sdx_response.py
+++ b/sdxlib/sdx_response.py
@@ -93,14 +93,14 @@ class SDXResponse:
             response_json, "description", str
         )
         self.notifications: Optional[List[Dict[str, str]]] = self._validate_optional(
-            response_json, "notifications", list
+            response_json, "notifications", list, default=[]
         )
         self.scheduling: Optional[Dict[str, str]] = self._validate_optional(
-            response_json, "scheduling", dict
+            response_json, "scheduling", dict, default={}
         )
         self.qos_metrics: Optional[
             Dict[str, Dict[str, Union[int, bool]]]
-        ] = self._validate_optional(response_json, "qos_metrics", dict)
+        ] = self._validate_optional(response_json, "qos_metrics", dict, default={})
 
         # Log successful validation
         self._logger.debug("SDXResponse successfully initialized.")
@@ -138,9 +138,9 @@ class SDXResponse:
 
         return value
 
-    def _validate_optional(self, data: dict, key: str, expected_type: type):
+    def _validate_optional(self, data: dict, key: str, expected_type: type, default=None):
         """Validates optional fields and ensures correct type if present."""
-        value = data.get(key)
+        value = data.get(key, default)
 
         if value is not None and not isinstance(value, expected_type):
             self._logger.warning(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sdxlib",
-    version="0.1",
+    version="0.35.1",
     packages=find_packages(),
     install_requires=["requests", "pycountry", "dacite",],
 )


### PR DESCRIPTION
Some attributes are optional on SDX L2VPN, however idx-lib was consuming them assuming they exists by default. For instance, notifications was supposed to be a list and sdx-lib was looping over that attribute assuming it always exists. That way, if you create a L2VPN outside from sdx-lib, then notifications would probably dont exists (i.e., `None`) and the loop over it would fail.

This PR assigns a default value for those attributes that are optional, for instance an empty list for notifications instead of None.