### PR TITLE
reject-unsupported-vlan-keyword-all-client-side-and-normalize-any-unt…

### DIFF
--- a/sdxlib/l2vpn.py
+++ b/sdxlib/l2vpn.py
@@ -2,6 +2,7 @@
 from typing import Dict, Any, List
 from sdxlib.request import _make_request
 from sdxlib.config import BASE_URL
+from sdxlib.response import normalize_result
 
 VERSION = "1.0"
 
@@ -15,7 +16,7 @@ def create_l2vpn(token: str, name: str, endpoints: List[Dict[str, str]], **kwarg
         extra_headers={"Authorization": f"Bearer {token}"},
         operation="create L2VPN",
     )
-    return {"status_code": status, "data": response, "error": None if status == 200 else str(response)}
+    return normalize_result(response, status, "create L2VPN")
 
 
 def update_l2vpn(token: str, service_id: str, **fields) -> dict:
@@ -27,7 +28,7 @@ def update_l2vpn(token: str, service_id: str, **fields) -> dict:
         extra_headers={"Authorization": f"Bearer {token}"},
         operation="update L2VPN",
     )
-    return {"status_code": status, "data": response, "error": None if status == 200 else str(response)}
+    return normalize_result(response, status, "update L2VPN")
 
 
 def delete_l2vpn(token: str, service_id: str) -> dict:
@@ -38,7 +39,7 @@ def delete_l2vpn(token: str, service_id: str) -> dict:
         extra_headers={"Authorization": f"Bearer {token}"},
         operation="delete L2VPN",
     )
-    return {"status_code": status, "data": response, "error": None if status == 200 else str(response)}
+    return normalize_result(response, status, "delete L2VPN")
 
 
 def get_l2vpn(token: str, service_id: str) -> Dict[str, Any]:
@@ -49,7 +50,5 @@ def get_l2vpn(token: str, service_id: str) -> Dict[str, Any]:
         extra_headers={"Authorization": f"Bearer {token}"},
         operation="get L2VPN",
     )
-    if status != 200 or not isinstance(response, dict):
-        return {"status_code": status, "error": "Failed to retrieve L2VPN", "data": response}
-    return response
+    return normalize_result(response, status, "get L2VPN")
 

--- a/sdxlib/response.py
+++ b/sdxlib/response.py
@@ -1,12 +1,26 @@
 # sdxlib/response.py
 """
-Normalize API responses into consistent dicts.
+Response normalization utilities for SDX library.
+
+Contract:
+- Callers SHOULD return a dict with keys: {"status_code", "data", "error"}.
+- Success (2xx):   {"status_code": <int>, "data": <payload>, "error": None}
+- Non-success:     {"status_code": <int>, "data": <payload>, "error": <short message>}
+
+This module centralizes the shaping of both success and error responses so that
+route wrappers (e.g., sdxlib/l2vpn.py) stay thin and never stringify large dicts
+into the "error" field.
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Any, Dict, List, Optional
 
+
+# ---------------------------
+# Success shapers (domain-specific)
+# ---------------------------
 
 def normalize_l2vpn_response(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Project raw L2VPN dicts into a stable, consumer-friendly shape."""
     return {
         "service_id": data.get("service_id", "unknown"),
         "name": data.get("name", ""),
@@ -25,4 +39,66 @@ def normalize_l2vpn_response(data: Dict[str, Any]) -> Dict[str, Any]:
         "scheduling": data.get("scheduling"),
         "qos_metrics": data.get("qos_metrics"),
     }
+
+
+# ---------------------------
+# Generic result shapers
+# ---------------------------
+
+def _derive_error_message(payload: Any, status_code: int, method: str) -> str:
+    """
+    Extract a concise message from a controller payload; fall back to a generic one.
+    - If payload is dict, prefer common error keys.
+    - If payload is text/other, truncate to a safe preview.
+    """
+    if isinstance(payload, dict):
+        message = (
+            payload.get("error")
+            or payload.get("message")
+            or payload.get("detail")
+            or payload.get("title")
+        )
+        if message:
+            return str(message)
+        # If the server wrapped a non-JSON error inside a dict (our HTTP helper may do this)
+        # try to surface a short 'body_sample' if present.
+        body_sample = payload.get("body_sample")
+        if isinstance(body_sample, str) and body_sample.strip():
+            return body_sample.strip()[:500]
+    # Fallback for non-dict bodies
+    text_preview = (str(payload) if payload is not None else "").strip()
+    if text_preview:
+        return text_preview[:500]
+    return f"{method} failed with status {status_code}"
+
+
+def normalize_error_response(
+    response_payload: Any,
+    status_code: int,
+    method: str = "operation",
+) -> Dict[str, Any]:
+    """
+    Wrap a failed API response into a consistent dict with a concise error message.
+    """
+    error_message = _derive_error_message(response_payload, status_code, method)
+    return {
+        "status_code": status_code,
+        "data": response_payload,
+        "error": error_message,
+    }
+
+
+def normalize_result(
+    response_payload: Any,
+    status_code: int,
+    method: str = "operation",
+) -> Dict[str, Any]:
+    """
+    Return a normalized result dict for both success and error cases.
+    - 2xx → error=None
+    - otherwise → concise error message derived from payload
+    """
+    if 200 <= status_code < 300:
+        return {"status_code": status_code, "data": response_payload, "error": None}
+    return normalize_error_response(response_payload, status_code, method)
 

--- a/sdxlib/validator.py
+++ b/sdxlib/validator.py
@@ -1,194 +1,25 @@
 # sdxlib/validator.py
 """
-Lightweight, function-only validators used by sdxlib.l2vpn and callers.
+Slim validators and HTTP error shaping for sdxlib.
 
-- No TokenAuth dependency
-- No sessions/DB lookups
-- Pure input validation & error-shaping utilities
+This module intentionally omits VLAN/endpoint validation logic.
+Those rules now live in the client layer (sdxclient), which validates
+request bodies before sending them to the controller.
+
+Provided here:
+- Basic input checks useful across routes (URL, name, notifications).
+- Controller error shaping with friendly messages.
 """
 
-import re
+from __future__ import annotations
+
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Union
+import re
+from typing import Any, Dict, List, Optional
+
 from requests.exceptions import HTTPError
 
-# ---------- basic constants ----------
-
-PORT_ID_PATTERN = r"^urn:sdx:port:[a-zA-Z0-9.,-_/]+:[a-zA-Z0-9.,-_/]+:[a-zA-Z0-9.,-_/]+$"
-ALLOWED_SPECIAL_VLANS = {"any", "all", "untagged"}
-
-# ---------- simple URL/name checks ----------
-
-def validate_required_url(base_url: str) -> str:
-    """Return base_url if it looks non-empty; raise otherwise."""
-    if not isinstance(base_url, str) or not base_url.strip():
-        raise ValueError("BASE_URL must be a non-empty string.")
-    return base_url
-
-def validate_required_attributes(base_url: str, name: Optional[str], endpoints: Optional[List[Dict[str, str]]]) -> None:
-    """Ensure minimal required fields before calling the controller."""
-    validate_required_url(base_url)
-    validate_name(name)
-    validate_endpoints(endpoints)
-
-def validate_name(name: Optional[str]) -> str:
-    """Non-empty <= 50 chars."""
-    if not isinstance(name, str) or not name.strip():
-        raise ValueError("name must be a non-empty string.")
-    if len(name) > 50:
-        raise ValueError("name must be at most 50 characters.")
-    return name
-
-# ---------- email / notifications ----------
-
-def is_valid_email(email: Any) -> bool:
-    return isinstance(email, str) and re.match(r"^\S+@\S+$", email) is not None
-
-def validate_notifications(notifications: Optional[List[Dict[str, str]]]) -> Optional[List[Dict[str, str]]]:
-    """List of {'email': 'user@example.org'} with size <= 10."""
-    if notifications is None:
-        return None
-    if not isinstance(notifications, list):
-        raise ValueError("notifications must be a list of objects with 'email'.")
-    if len(notifications) > 10:
-        raise ValueError("notifications can contain at most 10 entries.")
-    validated: List[Dict[str, str]] = []
-    for item in notifications:
-        if not isinstance(item, dict) or "email" not in item:
-            raise ValueError("each notification must be a dict with an 'email' key.")
-        if not is_valid_email(item["email"]):
-            raise ValueError(f"invalid email format: {item['email']}")
-        validated.append({"email": item["email"]})
-    return validated
-
-# ---------- VLAN / endpoint validation ----------
-
-def _validate_vlan_range(text: str) -> str:
-    """Accept 'A:B' where 1 <= A < B <= 4095."""
-    try:
-        left, right = map(int, text.split(":"))
-    except Exception:
-        raise ValueError(
-            f"invalid VLAN range '{text}'; expected 'A:B' with integers."
-        )
-    if not (1 <= left < right <= 4095):
-        raise ValueError("VLAN range values must satisfy 1 <= A < B <= 4095.")
-    return text
-
-def _validate_endpoint_dict(endpoint: Dict[str, Any]) -> Dict[str, str]:
-    if not isinstance(endpoint, dict):
-        raise TypeError("endpoint must be a dict.")
-    port_id = endpoint.get("port_id")
-    vlan = endpoint.get("vlan")
-    if not isinstance(port_id, str) or not re.match(PORT_ID_PATTERN, port_id):
-        raise ValueError(f"invalid port_id format: {port_id}")
-    if not isinstance(vlan, str) or not vlan.strip():
-        raise ValueError("endpoint requires 'vlan' as non-empty string.")
-
-    v = vlan.strip().lower()
-    if v in ALLOWED_SPECIAL_VLANS:
-        return {"port_id": port_id, "vlan": v}
-
-    if v.isdigit():
-        vid = int(v)
-        if 1 <= vid <= 4095:
-            return {"port_id": port_id, "vlan": v}
-        raise ValueError("VLAN must be between 1 and 4095.")
-
-    if ":" in v:
-        return {"port_id": port_id, "vlan": _validate_vlan_range(v)}
-
-    raise ValueError(
-        "vlan must be 'any'|'all'|'untagged', a number (1..4095), or a range 'A:B'."
-    )
-
-def validate_endpoints(endpoints: Optional[List[Dict[str, Any]]]) -> List[Dict[str, str]]:
-    """
-    - list with >= 2 entries
-    - all share a single VLAN semantics rule:
-      * if any endpoint uses a range -> all must use EXACTLY that same range
-      * if any uses special -> all must use the same special keyword
-      * otherwise single numeric VLAN -> all must use that same number
-    """
-    if not isinstance(endpoints, list) or len(endpoints) < 2:
-        raise ValueError("endpoints must be a list with at least 2 entries.")
-
-    validated = [_validate_endpoint_dict(ep) for ep in endpoints]
-    vlans = {ep["vlan"] for ep in validated}
-
-    # special cases must be uniform
-    if any(v in ALLOWED_SPECIAL_VLANS for v in vlans):
-        if len(vlans) != 1:
-            raise ValueError("when using 'any'|'all'|'untagged', all endpoints must use the same value.")
-        return validated
-
-    # range case must be uniform
-    if any(":" in v for v in vlans):
-        if len(vlans) != 1:
-            raise ValueError("when using VLAN ranges, all endpoints must share the same range.")
-        return validated
-
-    # numeric case must be uniform
-    if not all(v.isdigit() for v in vlans):
-        raise ValueError("mixed VLAN specification; use all numeric, all range, or the same special keyword.")
-    if len(vlans) != 1:
-        raise ValueError("all endpoints must use the same numeric VLAN.")
-    return validated
-
-# ---------- scheduling / QoS ----------
-
-_ISO8601_Z = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
-
-def is_valid_iso8601(ts: str) -> bool:
-    return isinstance(ts, str) and _ISO8601_Z.match(ts) is not None
-
-def validate_scheduling(scheduling: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
-    """Expect {'start_time': ISO8601Z, 'end_time': ISO8601Z}."""
-    if scheduling is None:
-        return None
-    if not isinstance(scheduling, dict):
-        raise TypeError("scheduling must be a dict.")
-    start = scheduling.get("start_time")
-    end = scheduling.get("end_time")
-    if start is not None and not is_valid_iso8601(start):
-        raise ValueError("start_time must be ISO8601 (YYYY-MM-DDTHH:MM:SSZ).")
-    if end is not None and not is_valid_iso8601(end):
-        raise ValueError("end_time must be ISO8601 (YYYY-MM-DDTHH:MM:SSZ).")
-    if start and end and end <= start:
-        raise ValueError("end_time must be after start_time.")
-    out: Dict[str, str] = {}
-    if start: out["start_time"] = start
-    if end:   out["end_time"] = end
-    return out or None
-
-def validate_qos_metrics(qos: Optional[Dict[str, Dict[str, Union[int, bool]]]]) -> Optional[Dict[str, Dict[str, Union[int, bool]]]]:
-    """
-    Accept keys in {'min_bw','max_delay','max_number_oxps'} with:
-      - value: int in a reasonable range
-      - strict: optional bool
-    """
-    if qos is None:
-        return None
-    if not isinstance(qos, dict):
-        raise TypeError("qos_metrics must be a dict.")
-    ranges = {"min_bw": (0, 100), "max_delay": (0, 1000), "max_number_oxps": (1, 100)}
-    out: Dict[str, Dict[str, Union[int, bool]]] = {}
-    for key, spec in qos.items():
-        if key not in ranges or not isinstance(spec, dict):
-            raise ValueError(f"invalid QoS metric: {key}")
-        val = spec.get("value")
-        strict = spec.get("strict")
-        if not isinstance(val, int):
-            raise ValueError(f"QoS '{key}.value' must be an int.")
-        lo, hi = ranges[key]
-        if not (lo <= val <= hi):
-            raise ValueError(f"QoS '{key}.value' must be between {lo} and {hi}.")
-        if "strict" in spec and not isinstance(strict, bool):
-            raise ValueError(f"QoS '{key}.strict' must be a bool.")
-        out[key] = {"value": val} if "strict" not in spec else {"value": val, "strict": strict}
-    return out
-
-# ---------- HTTP error shaping (optional helper) ----------
+# ---------- status → friendly message mapping ----------
 
 _METHOD_MESSAGES = {
     201: "L2VPN Service Created",
@@ -202,24 +33,85 @@ _METHOD_MESSAGES = {
     422: "Attribute not supported by SDX-LC/OXPO",
 }
 
-def map_http_error(logger: Optional[logging.Logger], exc: HTTPError, operation: str) -> Dict[str, Any]:
-    """Convert HTTPError into a consistent dict."""
+# ---------- simple input checks (generic) ----------
+
+def validate_required_url(base_url: str) -> str:
+    """Return base_url if it looks non-empty; raise otherwise."""
+    if not isinstance(base_url, str) or not base_url.strip():
+        raise ValueError("BASE_URL must be a non-empty string.")
+    return base_url
+
+
+def validate_name(name: Optional[str]) -> str:
+    """Non-empty name, max 50 chars."""
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("name must be a non-empty string.")
+    if len(name) > 50:
+        raise ValueError("name must be at most 50 characters.")
+    return name
+
+
+_EMAIL_RE = re.compile(r"^\S+@\S+$")
+
+def is_valid_email(email: Any) -> bool:
+    return isinstance(email, str) and _EMAIL_RE.match(email) is not None
+
+
+def validate_notifications(
+    notifications: Optional[List[Dict[str, str]]]
+) -> Optional[List[Dict[str, str]]]:
+    """
+    Accepts a list of {'email': 'user@example.org'} with size <= 10.
+    Returns a normalized list or None if notifications is None.
+    """
+    if notifications is None:
+        return None
+    if not isinstance(notifications, list):
+        raise ValueError("notifications must be a list of objects with 'email'.")
+    if len(notifications) > 10:
+        raise ValueError("notifications can contain at most 10 entries.")
+
+    normalized: List[Dict[str, str]] = []
+    for item in notifications:
+        if not isinstance(item, dict) or "email" not in item:
+            raise ValueError("each notification must be a dict with an 'email' key.")
+        email_value = item["email"]
+        if not is_valid_email(email_value):
+            raise ValueError(f"invalid email format: {email_value}")
+        normalized.append({"email": email_value})
+    return normalized
+
+# ---------- HTTP error shaping ----------
+
+def map_http_error(
+    logger: Optional[logging.Logger],
+    exc: HTTPError,
+    operation: str,
+) -> Dict[str, Any]:
+    """
+    Convert requests.HTTPError into a consistent dict while preserving
+    controller-provided details when available.
+    """
     if logger:
         logger.error("HTTP error during %s: %s", operation, exc)
+
     status = getattr(getattr(exc, "response", None), "status_code", None)
-    ctype = getattr(getattr(exc, "response", None), "headers", {}).get("Content-Type", "")
-    body = None
+    headers = getattr(getattr(exc, "response", None), "headers", {}) or {}
+    ctype = headers.get("Content-Type", "") or ""
+
+    details: Any
     try:
-        if "application/json" in (ctype or ""):
-            body = exc.response.json()
+        if "application/json" in ctype.lower():
+            details = exc.response.json()
         else:
-            body = exc.response.text
+            details = exc.response.text
     except Exception:
-        body = "unavailable"
+        details = "unavailable"
+
     return {
         "status_code": status or 0,
         "message": _METHOD_MESSAGES.get(status, "Unknown error"),
         "operation": operation,
-        "details": body,
+        "details": details,
     }
 


### PR DESCRIPTION
sdx-lib validates VLAN values before calling the Controller.
"all" is rejected client-side with a clear message (and guidance), since Controller does not support it.
If "any" or "untagged" is used, sdx-lib guarantees all endpoints share the same VLAN keyword and produces a single, consistent error if they do not.